### PR TITLE
Prevent Marker from leaking memory

### DIFF
--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/overlays/Marker.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/overlays/Marker.java
@@ -250,6 +250,14 @@ public class Marker extends OverlayWithIW {
 		drawAt(canvas, mIcon, mPositionPixels.x, mPositionPixels.y, false, rotationOnScreen);
 	}
 
+    /** Null out the static references when the MapView is detached to prevent memory leaks. */
+    @Override
+    public void onDetach(MapView mapView) {
+        mDefaultIcon = null;
+        mDefaultInfoWindow = null;
+        super.onDetach(mapView);
+    }
+
 	public boolean hitTest(final MotionEvent event, final MapView mapView){
 		final Projection pj = mapView.getProjection();
 		pj.toPixels(mPosition, mPositionPixels);


### PR DESCRIPTION
Keeping a static reference to DefaultInfoWindow prevents it from being GC'ed.
This is especially problematic as this in turn holds a reference to the parent
MapView. This leads to leaking the complete View hierarchy when the fragment
is detached.
To fix this, null out the reference when the parent MapView is detached.
In case of the default icon this is not as troublesome since Drawables only keep
weak references, but why not clean it up if possible.