### PR TITLE
Use one OkHttpClient for all requests

### DIFF
--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/utils/HttpConnection.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/utils/HttpConnection.java
@@ -26,19 +26,16 @@ import java.util.concurrent.TimeUnit;
  */
 public class HttpConnection {
 
-  private OkHttpClient client;
-  private InputStream stream;
-	private String mUserAgent;
+    private static OkHttpClient client;
+    private InputStream stream;
+    private String mUserAgent;
 
-	private final static int TIMEOUT_CONNECTION=3000; //ms
-	private final static int TIMEOUT_SOCKET=10000; //ms
-  private Object content;
+    private final static int TIMEOUT_CONNECTION = 3000; //ms
+    private final static int TIMEOUT_SOCKET = 10000; //ms
+    private Object content;
 
   public HttpConnection(){
 		stream = null;
-    client = new OkHttpClient();
-    client.setConnectTimeout(TIMEOUT_CONNECTION, TimeUnit.MILLISECONDS);
-    client.setReadTimeout(TIMEOUT_SOCKET, TimeUnit.MILLISECONDS);
   }
 
 	public void setUserAgent(String userAgent){
@@ -50,7 +47,7 @@ public class HttpConnection {
       Request.Builder request = new Request.Builder().url(url);
       if (mUserAgent != null)
         request.addHeader("User-Agent", mUserAgent);
-      Response response = client.newCall(request.build()).execute();
+      Response response = getOkHttpClient().newCall(request.build()).execute();
       Integer status = response.code();
       if (status != 200) {
         Log.e(BonusPackHelper.LOG_TAG, "Invalid response from server: " + status.toString());
@@ -90,7 +87,15 @@ public class HttpConnection {
 				e.printStackTrace();
 			}
 		}
-    if (client != null) client = null;
 	}
-	
+
+
+    public static OkHttpClient getOkHttpClient() {
+        if (client == null) {
+            client = new OkHttpClient();
+            client.setConnectTimeout(TIMEOUT_CONNECTION, TimeUnit.MILLISECONDS);
+            client.setReadTimeout(TIMEOUT_SOCKET, TimeUnit.MILLISECONDS);
+        }
+        return client;
+    }
 }


### PR DESCRIPTION
See the javadoc of the OkHttpClient class:
>Most applications can use a single OkHttpClient for all of their HTTP requests - benefiting from a shared response cache, thread pool, connection re-use, etc.

http://square.github.io/okhttp/2.x/okhttp/com/squareup/okhttp/OkHttpClient.html