### PR TITLE
Add gradle dependency information to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,32 @@ Start with the [installation guide](https://github.com/MKergall/osmbonuspack/wik
 
 In the [releases](https://github.com/MKergall/osmbonuspack/releases), you will find the library (jar file), the javadoc, and the [OSMNavigator](https://github.com/MKergall/osmbonuspack/wiki/OSMNavigator) application.
 
+# Gradle Dependency
+
+[![Release](https://img.shields.io/github/release/MKergall/osmbonuspack.svg?label=jitpack)](https://jitpack.io/#MKergall/osmbonuspack)
+
+Add this in your root `build.gradle` file (**not** your module `build.gradle` file):
+
+```gradle
+allprojects {
+	repositories {
+		...
+		maven { url "https://jitpack.io" }
+	}
+}
+```
+
+Add this in your module `build.gradle` file:
+
+```gradle
+dependencies {
+	...
+    compile('com.github.MKergall.osmbonuspack:OSMBonusPack:-SNAPSHOT@aar') {
+      transitive = true
+    }
+}
+```
+
 # How to get help
 If you need help to use osmdroid or OSMBonusPack, go to [StackOverflow](http://stackoverflow.com/questions/tagged/osmdroid) with "osmdroid" tag. 
 


### PR DESCRIPTION
This request includes information about Gradle Dependency through https://jitpack.io.

Now, it contains SNAPSHOT line for including, because:

**5.5** is *BUILD FAILED* - https://jitpack.io/com/github/MKergall/osmbonuspack/v5.5/build.log
**SNAPSHOT** is *BUILD SUCCESSFUL* - https://jitpack.io/com/github/MKergall/osmbonuspack/-v5.5-gecc04fa-12/build.log

but in future it can be replacing on stable release line.