### PR TITLE
Early Permission Code

### DIFF
--- a/OSMNavigator/src/main/java/com/osmnavigator/MapActivity.java
+++ b/OSMNavigator/src/main/java/com/osmnavigator/MapActivity.java
@@ -1,5 +1,6 @@
 package com.osmnavigator;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
@@ -7,6 +8,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -27,6 +29,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.provider.Settings;
+import android.support.v4.content.ContextCompat;
 import android.text.InputType;
 import android.util.Log;
 import android.view.ContextMenu;
@@ -228,9 +231,12 @@ public class MapActivity extends Activity implements MapEventsReceiver, Location
 		map.getOverlays().add(myLocationOverlay);
 
 		if (savedInstanceState == null){
-			Location location = mLocationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
-			if (location == null)
-				location = mLocationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
+            Location location = null;
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                location = mLocationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
+                if (location == null)
+                    location = mLocationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
+            }
 			if (location != null) {
 				//location known:
 				onLocationChanged(location);
@@ -510,7 +516,9 @@ public class MapActivity extends Activity implements MapEventsReceiver, Location
 	boolean startLocationUpdates(){
 		boolean result = false;
 		for (final String provider : mLocationManager.getProviders(true)) {
-			mLocationManager.requestLocationUpdates(provider, 2*1000, 0.0f, this);
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                mLocationManager.requestLocationUpdates(provider, 2 * 1000, 0.0f, this);
+            }
 			result = true;
 		}
 		return result;
@@ -529,7 +537,9 @@ public class MapActivity extends Activity implements MapEventsReceiver, Location
 
 	@Override protected void onPause() {
 		super.onPause();
-		mLocationManager.removeUpdates(this);
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            mLocationManager.removeUpdates(this);
+        }
 		//TODO: mSensorManager.unregisterListener(this);
 		stopSharingTimer();
 		savePrefs();


### PR DESCRIPTION
Early revision of my permission check code. Starting off with Navigator app and trying to track down all calls for Location and doing a permission check prior to making the call.

This will prevent the crash mentioned in issue #192, but does not address requesting the permissions. I think it would be smart to export the onCreate() location calls into the **startLocationUpdates()**.

This is a bit challenging as I could implement the Locationpermission call inside **startLocationUpdates**. I could lump in the storage call here as well which should provide a good workflow.

I'll revisit this later.