### PR TITLE
Preventing marker's memory leaks explicitly

### DIFF
--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/overlays/Marker.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/overlays/Marker.java
@@ -251,10 +251,14 @@ public class Marker extends OverlayWithIW {
     /** Null out the static references when the MapView is detached to prevent memory leaks. */
 	@Override
 	public void onDetach(MapView mapView) {
-		mDefaultIcon = null;
-        mDefaultInfoWindow = null;
+		cleanDefaults();
         super.onDetach(mapView);
     }
+
+	public static void cleanDefaults(){
+		mDefaultIcon = null;
+		mDefaultInfoWindow = null;
+	}
 
 	public boolean hitTest(final MotionEvent event, final MapView mapView){
 		final Projection pj = mapView.getProjection();


### PR DESCRIPTION
Hello. If all markers were removed from MapView before onDetach was called, Marker's mDefaultInfoWindow still can leak. I verified the leak here (https://github.com/hakami1024/osmbonuspack/commit/e3b9efc2c5e46275c64d5b981f974311613b5ae8). Could you add more explicit way to get rid of the leak?