### PR TITLE
Osm geo changes

### DIFF
--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/kml/KmlDocument.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/kml/KmlDocument.java
@@ -203,7 +203,12 @@ public class KmlDocument implements Parcelable {
 	public boolean parseKMLUrl(String url){
 		Log.d(BonusPackHelper.LOG_TAG, "KmlProvider.parseKMLUrl:"+url);
 		HttpConnection connection = new HttpConnection();
-		connection.doGet(url);
+		try {
+			connection.doGet(url);
+		} catch (Exception e) {
+			e.printStackTrace();
+			return false;
+		}
 		InputStream stream = connection.getStream();
 		boolean ok;
 		if (stream == null){

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/FlickrPOIProvider.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/FlickrPOIProvider.java
@@ -6,9 +6,12 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.osmdroid.bonuspack.utils.BonusPackHelper;
+import org.osmdroid.bonuspack.utils.StatusException;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 
 /**
@@ -97,12 +100,12 @@ public class FlickrPOIProvider {
 	 * @param fullUrl
 	 * @return the list of POI
 	 */
-	public ArrayList<POI> getThem(String fullUrl){
+	public ArrayList<POI> getThem(String fullUrl) throws IOException, StatusException {
 		Log.d(BonusPackHelper.LOG_TAG, "FlickrPOIProvider:get:"+fullUrl);
 		String jString = BonusPackHelper.requestStringFromUrl(fullUrl);
 		if (jString == null) {
 			Log.e(BonusPackHelper.LOG_TAG, "FlickrPOIProvider: request failed.");
-			return null;
+			throw new StatusException(HttpURLConnection.HTTP_NO_CONTENT);
 		}
 		try {
 			JSONObject jRoot = new JSONObject(jString);
@@ -138,7 +141,7 @@ public class FlickrPOIProvider {
 	 * @param maxResults
 	 * @return list of POI, Flickr photos inside the bounding box. Null if technical issue. 
 	 */
-	public ArrayList<POI> getPOIInside(BoundingBox boundingBox, int maxResults){
+	public ArrayList<POI> getPOIInside(BoundingBox boundingBox, int maxResults) throws IOException, StatusException {
 		String url = getUrlInside(boundingBox, maxResults);
 		return getThem(url);
 	}

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/GeoNamesPOIProvider.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/GeoNamesPOIProvider.java
@@ -7,6 +7,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.osmdroid.bonuspack.utils.BonusPackHelper;
 import org.osmdroid.bonuspack.utils.HttpConnection;
+import org.osmdroid.bonuspack.utils.StatusException;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.xml.sax.Attributes;
@@ -15,6 +16,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -67,12 +69,12 @@ public class GeoNamesPOIProvider {
 	 * @param fullUrl
 	 * @return the list of POI
 	 */
-	public ArrayList<POI> getThem(String fullUrl){
+	public ArrayList<POI> getThem(String fullUrl) throws IOException, StatusException {
 		Log.d(BonusPackHelper.LOG_TAG, "GeoNamesPOIProvider:get:"+fullUrl);
 		String jString = BonusPackHelper.requestStringFromUrl(fullUrl);
 		if (jString == null) {
 			Log.e(BonusPackHelper.LOG_TAG, "GeoNamesPOIProvider: request failed.");
-			return null;
+			throw new StatusException(HttpURLConnection.HTTP_NO_CONTENT);
 		}
 		try {
 			JSONObject jRoot = new JSONObject(jString);
@@ -113,7 +115,11 @@ public class GeoNamesPOIProvider {
 	public ArrayList<POI> getThemXML(String fullUrl){
 		Log.d(BonusPackHelper.LOG_TAG, "GeoNamesPOIProvider:get:"+fullUrl);
 		HttpConnection connection = new HttpConnection();
-		connection.doGet(fullUrl);
+		try {
+			connection.doGet(fullUrl);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 		InputStream stream = connection.getStream();
 		if (stream == null){
 			return null;
@@ -141,7 +147,7 @@ public class GeoNamesPOIProvider {
 	 * @return list of POI, Wikipedia entries close to the position. Null if technical issue. 
 	 */
 	public ArrayList<POI> getPOICloseTo(GeoPoint position, 
-			int maxResults, double maxDistance){
+			int maxResults, double maxDistance) throws IOException, StatusException {
 		String url = getUrlCloseTo(position, maxResults, maxDistance);
 		return getThem(url);
 	}
@@ -151,7 +157,7 @@ public class GeoNamesPOIProvider {
 	 * @param maxResults
 	 * @return list of POI, Wikipedia entries inside the bounding box. Null if technical issue. 
 	 */
-	public ArrayList<POI> getPOIInside(BoundingBox boundingBox, int maxResults){
+	public ArrayList<POI> getPOIInside(BoundingBox boundingBox, int maxResults) throws IOException, StatusException {
 		String url = getUrlInside(boundingBox, maxResults);
 		return getThem(url);
 	}

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/GeocoderGisgraphy.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/GeocoderGisgraphy.java
@@ -7,8 +7,10 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.osmdroid.bonuspack.utils.BonusPackHelper;
+import org.osmdroid.bonuspack.utils.StatusException;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
@@ -106,8 +108,7 @@ public class GeocoderGisgraphy {
 	/**
 	 * Equivalent to Geocoder::getFromLocation(String locationName, int maxResults). 
 	 */
-	public List<Address> getFromLocationName(String locationName, int maxResults)
-	throws IOException {
+	public List<Address> getFromLocationName(String locationName, int maxResults) throws IOException, StatusException {
 		String url = mServiceUrl
 			+ "geocoding/geocode?"
 			+ "format=json"
@@ -117,7 +118,7 @@ public class GeocoderGisgraphy {
 		String result = BonusPackHelper.requestStringFromUrl(url);
 		//Log.d(BonusPackHelper.LOG_TAG, result);
 		if (result == null)
-			throw new IOException();
+			throw new StatusException(HttpURLConnection.HTTP_NO_CONTENT);
 		try {
 			JSONObject jsonResult = new JSONObject(result);
 			JSONArray jResults = jsonResult.getJSONArray("result");

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/NominatimPOIProvider.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/NominatimPOIProvider.java
@@ -7,9 +7,12 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.osmdroid.bonuspack.utils.BonusPackHelper;
+import org.osmdroid.bonuspack.utils.StatusException;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 
@@ -78,12 +81,12 @@ public class NominatimPOIProvider {
 	 * @param url full URL request. Assumes
 	 * @return the list of POI, of null if technical issue. 
 	 */
-	public ArrayList<POI> getThem(String url){
+	public ArrayList<POI> getThem(String url) throws IOException, StatusException {
 		Log.d(BonusPackHelper.LOG_TAG, "NominatimPOIProvider:get:"+url);
 		String jString = BonusPackHelper.requestStringFromUrl(url, mUserAgent);
 		if (jString == null) {
 			Log.e(BonusPackHelper.LOG_TAG, "NominatimPOIProvider: request failed.");
-			return null;
+			throw new StatusException(HttpURLConnection.HTTP_NO_CONTENT);
 		}
 		try {
 			JSONArray jPlaceIds = new JSONArray(jString);
@@ -128,7 +131,7 @@ public class NominatimPOIProvider {
 	 * @return the list of POI close to position, null if technical issue.
 	 */
 	public ArrayList<POI> getPOICloseTo(GeoPoint position, String facility, 
-			int maxResults, double maxDistance){
+			int maxResults, double maxDistance) throws IOException, StatusException {
 		String url = getUrlCloseTo(position, facility, maxResults, maxDistance);
 		return getThem(url);
 	}
@@ -139,7 +142,7 @@ public class NominatimPOIProvider {
 	 * @param maxResults
 	 * @return list of POIs inside the bounding box, null if technical issue.
 	 */
-	public ArrayList<POI> getPOIInside(BoundingBox boundingBox, String facility, int maxResults){
+	public ArrayList<POI> getPOIInside(BoundingBox boundingBox, String facility, int maxResults) throws IOException, StatusException {
 		String url = getUrlInside(boundingBox, facility, maxResults);
 		return getThem(url);
 	}
@@ -155,7 +158,7 @@ public class NominatimPOIProvider {
 	 * @see org.osmdroid.bonuspack.routing.Road#getRouteLow for simplifying a route path
 	 */
 	public ArrayList<POI> getPOIAlong(ArrayList<GeoPoint> path, String facility, 
-		int maxResults, double maxWidth){
+		int maxResults, double maxWidth) throws IOException, StatusException {
 		StringBuilder url = getCommonUrl(facility, maxResults);
 		url.append("&routewidth="+maxWidth);
 		url.append("&route=");

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/OverpassAPIProvider.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/OverpassAPIProvider.java
@@ -16,9 +16,12 @@ import org.osmdroid.bonuspack.kml.KmlPlacemark;
 import org.osmdroid.bonuspack.kml.KmlPoint;
 import org.osmdroid.bonuspack.kml.KmlPolygon;
 import org.osmdroid.bonuspack.utils.BonusPackHelper;
+import org.osmdroid.bonuspack.utils.StatusException;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Map;
@@ -109,12 +112,12 @@ public class OverpassAPIProvider {
 	 * - ways and relations must contain the "center" element. <br>
 	 * @return elements as a list of POI
 	 */
-	public ArrayList<POI> getPOIsFromUrl(String url){
+	public ArrayList<POI> getPOIsFromUrl(String url) throws IOException, StatusException {
 		Log.d(BonusPackHelper.LOG_TAG, "OverpassAPIProvider:getPOIsFromUrl:"+url);
 		String jString = BonusPackHelper.requestStringFromUrl(url);
 		if (jString == null) {
 			Log.e(BonusPackHelper.LOG_TAG, "OverpassAPIProvider: request failed.");
-			return null;
+			throw new StatusException(HttpURLConnection.HTTP_NO_CONTENT);
 		}
 		try {
 			//parse JSON and build POIs
@@ -260,7 +263,7 @@ public class OverpassAPIProvider {
 	 * - ways and relations must have the "geometry" element<br>
 	 * @return true if ok, false if technical error. 
 	 */
-	public boolean addInKmlFolder(KmlFolder kmlFolder, String url){
+	public boolean addInKmlFolder(KmlFolder kmlFolder, String url) throws IOException, StatusException {
 		Log.d(BonusPackHelper.LOG_TAG, "OverpassAPIProvider:addInKmlFolder:"+url);
 		String jString = BonusPackHelper.requestStringFromUrl(url);
 		if (jString == null) {

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/PicasaPOIProvider.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/PicasaPOIProvider.java
@@ -57,7 +57,12 @@ public class PicasaPOIProvider {
 	public ArrayList<POI> getThem(String fullUrl){
 		Log.d(BonusPackHelper.LOG_TAG, "PicasaPOIProvider:get:"+fullUrl);
 		HttpConnection connection = new HttpConnection();
-		connection.doGet(fullUrl);
+		try {
+			connection.doGet(fullUrl);
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
 		InputStream stream = connection.getStream();
 		if (stream == null){
 			return null;

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/GoogleRoadManager.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/GoogleRoadManager.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import org.osmdroid.bonuspack.utils.BonusPackHelper;
 import org.osmdroid.bonuspack.utils.HttpConnection;
 import org.osmdroid.bonuspack.utils.PolylineEncoder;
+import org.osmdroid.bonuspack.utils.StatusException;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.xml.sax.Attributes;
@@ -65,8 +66,10 @@ public class GoogleRoadManager extends RoadManager {
 	/** 
 	 * @param waypoints list of GeoPoints. Must have at least 2 entries, start and end points. 
 	 * @return the roads
+	 * @throws IOException if there is problem with internet connection
+	 * @throws StatusException if there si some problem other then internet connection. For problem details see {@link StatusException#getHttpStatusCode()}
 	 */
-	protected Road[] getRoads(ArrayList<GeoPoint> waypoints, boolean getAlternate) {
+	protected Road[] getRoads(ArrayList<GeoPoint> waypoints, boolean getAlternate) throws IOException, StatusException {
 		String url = getUrl(waypoints, getAlternate);
 		Log.d(BonusPackHelper.LOG_TAG, "GoogleRoadManager.getRoads:" + url);
 		Road[] roads = null;
@@ -95,11 +98,11 @@ public class GoogleRoadManager extends RoadManager {
 		return roads;
 	}
 
-	@Override public Road[] getRoads(ArrayList<GeoPoint> waypoints) {
+	@Override public Road[] getRoads(ArrayList<GeoPoint> waypoints) throws IOException, StatusException {
 		return getRoads(waypoints, true);
 	}
 
-	@Override public Road getRoad(ArrayList<GeoPoint> waypoints) {
+	@Override public Road getRoad(ArrayList<GeoPoint> waypoints) throws IOException, StatusException {
 		Road[] roads = getRoads(waypoints, false);
 		return roads[0];
 	}

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/GraphHopperRoadManager.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/GraphHopperRoadManager.java
@@ -7,9 +7,11 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.osmdroid.bonuspack.utils.BonusPackHelper;
 import org.osmdroid.bonuspack.utils.PolylineEncoder;
+import org.osmdroid.bonuspack.utils.StatusException;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -90,7 +92,7 @@ public class GraphHopperRoadManager extends RoadManager {
 		return roads;
 	}
 
-	public Road[] getRoads(ArrayList<GeoPoint> waypoints, boolean getAlternate) {
+	public Road[] getRoads(ArrayList<GeoPoint> waypoints, boolean getAlternate) throws IOException, StatusException {
 		String url = getUrl(waypoints, getAlternate);
 		Log.d(BonusPackHelper.LOG_TAG, "GraphHopper.getRoads:" + url);
 		String jString = BonusPackHelper.requestStringFromUrl(url);
@@ -146,12 +148,12 @@ public class GraphHopperRoadManager extends RoadManager {
 		}
 	}
 
-	@Override public Road[] getRoads(ArrayList<GeoPoint> waypoints) {
+	@Override public Road[] getRoads(ArrayList<GeoPoint> waypoints) throws IOException, StatusException {
 		return getRoads(waypoints, true);
 	}
 
 	@Override
-	public Road getRoad(ArrayList<GeoPoint> waypoints) {
+	public Road getRoad(ArrayList<GeoPoint> waypoints) throws IOException, StatusException {
 		Road[] roads = getRoads(waypoints, false);
 		return roads[0];
 	}

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/MapQuestRoadManager.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/MapQuestRoadManager.java
@@ -5,12 +5,14 @@ import android.util.Log;
 import org.osmdroid.bonuspack.utils.BonusPackHelper;
 import org.osmdroid.bonuspack.utils.HttpConnection;
 import org.osmdroid.bonuspack.utils.PolylineEncoder;
+import org.osmdroid.bonuspack.utils.StatusException;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 
@@ -79,8 +81,10 @@ public class MapQuestRoadManager extends RoadManager {
 	/**
 	 * @param waypoints list of GeoPoints. Must have at least 2 entries, start and end points. 
 	 * @return the road
+	 * @throws IOException if there is problem with internet connection
+	 * @throws StatusException if there si some problem other then internet connection. For problem details see {@link StatusException#getHttpStatusCode()}
 	 */
-	@Override public Road getRoad(ArrayList<GeoPoint> waypoints) {
+	@Override public Road getRoad(ArrayList<GeoPoint> waypoints) throws IOException, StatusException {
 		String url = getUrl(waypoints);
 		Log.d(BonusPackHelper.LOG_TAG, "MapQuestRoadManager.getRoute:"+url);
 		Road road = null;
@@ -94,7 +98,7 @@ public class MapQuestRoadManager extends RoadManager {
 		return road;
 	}
 
-	@Override public Road[] getRoads(ArrayList<GeoPoint> waypoints) {
+	@Override public Road[] getRoads(ArrayList<GeoPoint> waypoints) throws IOException, StatusException {
 		Road road = getRoad(waypoints);
 		Road[] roads = new Road[1];
 		roads[0] = road;

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/OSRMRoadManager.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/OSRMRoadManager.java
@@ -9,9 +9,11 @@ import org.json.JSONObject;
 import org.osmdroid.bonuspack.R;
 import org.osmdroid.bonuspack.utils.BonusPackHelper;
 import org.osmdroid.bonuspack.utils.PolylineEncoder;
+import org.osmdroid.bonuspack.utils.StatusException;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -185,7 +187,7 @@ public class OSRMRoadManager extends RoadManager {
 		return roads;
 	}
 
-	protected Road[] getRoads(ArrayList<GeoPoint> waypoints, boolean getAlternate) {
+	protected Road[] getRoads(ArrayList<GeoPoint> waypoints, boolean getAlternate) throws IOException, StatusException {
 		String url = getUrl(waypoints, getAlternate);
 		Log.d(BonusPackHelper.LOG_TAG, "OSRMRoadManager.getRoads:" + url);
 		//url = "http://comob.free.fr/osrm_sample.json"; //DEBUG - waiting for OSRM V5 live
@@ -276,11 +278,11 @@ public class OSRMRoadManager extends RoadManager {
 		}
 	}
 
-	@Override public Road[] getRoads(ArrayList<GeoPoint> waypoints) {
+	@Override public Road[] getRoads(ArrayList<GeoPoint> waypoints) throws IOException, StatusException {
 		return getRoads(waypoints, true);
 	}
 
-	@Override public Road getRoad(ArrayList<GeoPoint> waypoints) {
+	@Override public Road getRoad(ArrayList<GeoPoint> waypoints) throws IOException, StatusException {
 		Road[] roads = getRoads(waypoints, false);
 		return roads[0];
 	}

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/RoadManager.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/RoadManager.java
@@ -1,8 +1,10 @@
 package org.osmdroid.bonuspack.routing;
 
+import org.osmdroid.bonuspack.utils.StatusException;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.overlay.Polyline;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 /**
@@ -23,8 +25,10 @@ public abstract class RoadManager {
 	 * @param waypoints
 	 * @return the road found.
 	 * In case of error, road status is set to error, and the shape has just straight lines between waypoints.
+	 * @throws IOException if there is problem with internet connection
+	 * @throws StatusException if there si some problem other then internet connection. For problem details see {@link StatusException#getHttpStatusCode()}
 	 */
-	public abstract Road getRoad(ArrayList<GeoPoint> waypoints);
+	public abstract Road getRoad(ArrayList<GeoPoint> waypoints) throws IOException, StatusException;
 
 	/**
 	 * @param waypoints
@@ -32,8 +36,10 @@ public abstract class RoadManager {
 	 * Road at index 0 is the shortest (in time).
 	 * The array may contain more entries, for alternate routes - assuming the routing service used supports alternate routes.
 	 * In case of error, return 1 road with its status set to error, and its shape with just straight lines between waypoints.
+	 * @throws IOException if there is problem with internet connection
+	 * @throws StatusException if there si some problem other then internet connection. For problem details see {@link StatusException#getHttpStatusCode()}
 	 */
-	public abstract Road[] getRoads(ArrayList<GeoPoint> waypoints);
+	public abstract Road[] getRoads(ArrayList<GeoPoint> waypoints) throws IOException, StatusException;
 
 	public RoadManager() {
 		mOptions = "";

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/utils/BonusPackHelper.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/utils/BonusPackHelper.java
@@ -62,8 +62,10 @@ public class BonusPackHelper {
 	 * @param url
 	 * @param userAgent
 	 * @return the whole content, or null if any issue.
+	 * @throws IOException if there is problem with internet connection
+	 * @throws StatusException if there si some problem other then internet connection. For problem details see {@link StatusException#getHttpStatusCode()}
 	 */
-	public static String requestStringFromUrl(String url, String userAgent) {
+	public static String requestStringFromUrl(String url, String userAgent) throws IOException, StatusException {
 		HttpConnection connection = new HttpConnection();
 		if (userAgent != null)
 			connection.setUserAgent(userAgent);
@@ -75,9 +77,11 @@ public class BonusPackHelper {
 
 	/** sends an http request, and returns the whole content result in a String.
 	 * @param url
-	 * @return the whole content, or null if any issue. 
+	 * @return the whole content, or null if any issue.
+	 * @throws IOException if there is problem with internet connection
+	 * @throws StatusException if there si some problem other then internet connection. For problem details see {@link StatusException#getHttpStatusCode()}
 	 */
-	public static String requestStringFromUrl(String url) {
+	public static String requestStringFromUrl(String url) throws IOException, StatusException {
 		return requestStringFromUrl(url, null);
 	}
 

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/utils/HttpConnection.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/utils/HttpConnection.java
@@ -60,18 +60,19 @@ public class HttpConnection {
 		mUserAgent = userAgent;
 	}
 
-	public void doGet(final String url) {
-        try {
-            Request.Builder request = new Request.Builder().url(url);
-            if (mUserAgent != null)
-                request.addHeader("User-Agent", mUserAgent);
-            response = getOkHttpClient().newCall(request.build()).execute();
-            Integer status = response.code();
-            if (status != 200) {
-                Log.e(BonusPackHelper.LOG_TAG, "Invalid response from server: " + status.toString());
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
+    /**
+     * @throws IOException if there is problem with internet connection
+     * @throws StatusException if there si some problem other then internet connection. For problem details see {@link StatusException#getHttpStatusCode()}
+     * */
+	public void doGet(final String url) throws StatusException, IOException {
+        Request.Builder request = new Request.Builder().url(url);
+        if (mUserAgent != null)
+            request.addHeader("User-Agent", mUserAgent);
+        response = getOkHttpClient().newCall(request.build()).execute();
+        Integer status = response.code();
+        if (status != 200) {
+            Log.e(BonusPackHelper.LOG_TAG, "Invalid response from server: " + status.toString());
+            throw new StatusException(status);
         }
   }
 

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/utils/StatusException.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/utils/StatusException.java
@@ -1,0 +1,39 @@
+package org.osmdroid.bonuspack.utils;
+
+/**
+ * Exception thrown when server returned status different from http status code 200.
+ * This means there is connection to server just some problem occurred. For problem details see
+ * http status code {@link #getHttpStatusCode()}.
+ * */
+public class StatusException extends Exception {
+
+    private static final long serialVersionUID = 4703847528972168524L;
+
+    private int httpStatusCode;
+
+    public StatusException(int httpStatusCode) {
+        super("HTTP STATUS CODE: "+httpStatusCode);
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public StatusException(String message, int httpStatusCode) {
+        super(message);
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public StatusException(String message, Throwable cause, int httpStatusCode) {
+        super(message, cause);
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public StatusException(Throwable cause, int httpStatusCode) {
+        super(cause);
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    /** @return httpStatusCode - http status code returned from server. */
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+}


### PR DESCRIPTION
Hi,

I made some changes that i find useful to have. Often It is useful to know what problem happened in request that is made. Like if want to make route request and currently there is no internet connection or server is not reachable so user can be properly informed about problem. second change is more detailed Address info returned in geocoding/reversegeocoding. 

So changes are:
- in HttpConnection class doGet method now throws IOException if there is problem with internet connection and StatusException if there si some problem other then internet connection. StatusException class contains method getHttpStatusCode() that returns http status code for more details about problem. This offers more details about communication problems. This caused that all request methods that uses HttpConnection.doGet() had to throw this exceptions.

- in GeocoderNominatim class method buildAndroidAddress supported new tags from OSM. Setting of street address using tag "road" have added fallbacks to values with tags: "pedestrian", "footway", "cycleway", "bridleway", "highway", "address26". Tag "county" has set fallback value to tag "departement". Tag "state" has set fallback value to tag "region".
Tag "house_number" set now in Address object with setSubThoroughfare() (since in documentations says: "This may correspond to the street number of the address") among others that are set mostly in Address extras Bundle. It is useful to have more address details espectialy in some countries where different tags are used. Some of tags added in Address extras if they exsist in response: "place_id", "type", "licence", "city", "town", "village", "subway", "golf_course", "bus_stop", "parking", "house", "building", "city_district", "pedestrian", "footway", "highway", "sub-city", "locality", "isolated_dwelling",  "cycleway", "hamlet", "region", "departement", "neighbourhood", "residential".