### PR TITLE
Added ability to set a listener for clicks on Cluster Markers

### DIFF
--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/clustering/MarkerClusterer.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/clustering/MarkerClusterer.java
@@ -11,6 +11,7 @@ import org.osmdroid.views.overlay.Overlay;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.ListIterator;
 
 /** 
@@ -28,7 +29,8 @@ public abstract class MarkerClusterer extends Overlay {
 
 	/** impossible value for zoom level, to force clustering */
 	protected static final int FORCE_CLUSTERING = -1;
-	
+
+	protected OnMarkerClusterClickListener mMarkerClusterClickListener;
 	protected ArrayList<Marker> mItems = new ArrayList<Marker>();
 	protected Point mPoint = new Point();
 	protected ArrayList<StaticCluster> mClusters = new ArrayList<StaticCluster>();
@@ -93,7 +95,16 @@ public abstract class MarkerClusterer extends Overlay {
 	public ArrayList<Marker> getItems(){
 		return mItems;
 	}
-	
+
+	/** @return the listener for cluster marker clicks **/
+	public OnMarkerClusterClickListener getMarkerClusterClickListener() {
+		return mMarkerClusterClickListener;
+	}
+	/** Set the listener for clicks on a cluster **/
+	public void setMarkerClusterClickListener(OnMarkerClusterClickListener markerClusterClickListener) {
+		mMarkerClusterClickListener = markerClusterClickListener;
+	}
+
 	@Override protected void draw(Canvas canvas, MapView mapView, boolean shadow) {
 		//if zoom has changed and mapView is now stable, rebuild clusters:
 		int zoomLevel = mapView.getZoomLevel();
@@ -155,5 +166,9 @@ public abstract class MarkerClusterer extends Overlay {
 				return true;
 		}
 		return false;
+	}
+
+	public interface OnMarkerClusterClickListener {
+		boolean onMarkerClusterClick(StaticCluster cluster, MapView mapView);
 	}
 }

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/clustering/RadiusMarkerClusterer.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/clustering/RadiusMarkerClusterer.java
@@ -17,6 +17,7 @@ import org.osmdroid.views.overlay.Marker;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Radius-based Clustering algorithm:
@@ -113,11 +114,20 @@ public class RadiusMarkerClusterer extends MarkerClusterer {
         return cluster;
     }
 
-    @Override public Marker buildClusterMarker(StaticCluster cluster, MapView mapView) {
-        Marker m = new Marker(mapView);
+    @Override public Marker buildClusterMarker(final StaticCluster cluster, final MapView mapView) {
+        final Marker m = new Marker(mapView);
         m.setPosition(cluster.getPosition());
         m.setInfoWindow(null);
         m.setAnchor(mAnchorU, mAnchorV);
+        m.setOnMarkerClickListener(new Marker.OnMarkerClickListener() {
+            @Override
+            public boolean onMarkerClick(Marker marker, MapView mapView) {
+                if (mMarkerClusterClickListener != null){
+                    mMarkerClusterClickListener.onMarkerClusterClick(cluster, mapView);
+                }
+                return false;
+            }
+        });
 
         Bitmap finalIcon = Bitmap.createBitmap(mClusterIcon.getWidth(), mClusterIcon.getHeight(), mClusterIcon.getConfig());
         Canvas iconCanvas = new Canvas(finalIcon);

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/clustering/StaticCluster.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/clustering/StaticCluster.java
@@ -33,7 +33,11 @@ public class StaticCluster {
 	public Marker getItem(int index) {
 	    return mItems.get(index);
 	}
-	
+
+	public ArrayList<Marker> getItems(){
+		return mItems;
+	}
+
 	public boolean add(Marker t) {
 	    return mItems.add(t);
 	}


### PR DESCRIPTION
Currently there is **no** way to register any kind of listener or like that to get the event, when a cluster was clicked. Code of this PR makes it possible.
* Allow to set a `OnMarkerClusterClickListener` in the super-class `MarkerCluster`
* Implementation for `RadiusMarkerClusterer`
* Allow to get all items from a `StaticCluster`