### PR TITLE
Prevent scientific notation when encoding double as string in lat/lon

### DIFF
--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/OSRMRoadManager.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/OSRMRoadManager.java
@@ -138,7 +138,7 @@ public class OSRMRoadManager extends RoadManager {
 			GeoPoint p = waypoints.get(i);
 			if (i>0)
 				urlString.append(';');
-			urlString.append(Double.toString(p.getLongitude()) + "," + Double.toString(p.getLatitude()));
+			urlString.append(geoPointAsLonLatString(p));
 		}
 		urlString.append("?alternatives="+(getAlternate?"true" : "false"));
 		urlString.append("&overview=full&steps=true");

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/RoadManager.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/routing/RoadManager.java
@@ -3,6 +3,7 @@ package org.osmdroid.bonuspack.routing;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.overlay.Polyline;
 
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 
 /**
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 public abstract class RoadManager {
 
   protected String mOptions;
+  final protected DecimalFormat mLatLonFormat = new DecimalFormat("0.000000");
 
 	/**
 	 * @param waypoints
@@ -53,13 +55,16 @@ public abstract class RoadManager {
 	 * @return the GeoPoint as a string, properly formatted: lat,lon
 	 */
 	protected String geoPointAsString(GeoPoint p){
-		StringBuilder result = new StringBuilder();
-		double d = p.getLatitude();
-		result.append(Double.toString(d));
-		d = p.getLongitude();
-		result.append(",");
-		result.append(Double.toString(d));
-		return result.toString();
+		return mLatLonFormat.format(p.getLatitude())  + ',' +
+				mLatLonFormat.format(p.getLongitude());
+	}
+
+	/**
+	 * @return the GeoPoint as a string, properly formatted: lon,lat
+	 */
+	protected String geoPointAsLonLatString(GeoPoint p){
+		return mLatLonFormat.format(p.getLongitude())  + ',' +
+				mLatLonFormat.format(p.getLatitude());
 	}
 	
 	/**


### PR DESCRIPTION
Points with longitude close to Greenwich (-0.000065 in the bellow example) or latitude near the equator are encoded as strings with scientific notation (with exponent). The calls to some external APIs aren't successfull in these cases. The bellow example tries to get the route between two locations in London.

OSRM:
http://router.project-osrm.org/route/v1/driving/0.003969,51.551236;-6.5E-5,51.551502?alternatives=false&overview=full&steps=true

Response:
{"message":"Query string malformed close to position 41","code":"InvalidQuery"}

Google:
http://maps.googleapis.com/maps/api/directions/xml?origin=51.551236,0.003969&destination=51.551502,-6.5E-5&alternatives=false&units=metric&language=en

Response:

<DirectionsResponse>
  <status>ZERO_RESULTS</status>
  <geocoded_waypoint/>
  <geocoded_waypoint>
    <geocoder_status>OK</geocoder_status>
    <type>political</type>
    <type>sublocality</type>
    <type>sublocality_level_2</type>
    <partial_match>true</partial_match>
    <place_id>ChIJGdDAEQlfUjoRAoYTdx02G-w</place_id>
  </geocoded_waypoint>
</DirectionsResponse>

MapQuest API parses it successfuly and returns the correct response.


However the urls bellow will work normaly in both OSRM and Goofle APIs:

http://router.project-osrm.org/route/v1/driving/0.003969,51.551236;-0.000065,51.551502?alternatives=false&overview=full&steps=true


http://maps.googleapis.com/maps/api/directions/xml?origin=51.551236,0.003969&destination=51.551502,-0.000065&alternatives=false&units=metric&language=en