### PR TITLE
Added house numbers in reverse geocoding. (SubThoroughfare)

### DIFF
--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/GeocoderNominatim.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/GeocoderNominatim.java
@@ -97,11 +97,17 @@ public class GeocoderNominatim {
 			gAddress.setAddressLine(addressIndex++, jAddress.get("road").getAsString());
 			gAddress.setThoroughfare(jAddress.get("road").getAsString());
 		}
+
+		if (jAddress.has("house_number")){
+			gAddress.setSubThoroughfare(jAddress.get("house_number").getAsString());
+		}
+
 		if (jAddress.has("suburb")){
 			//gAddress.setAddressLine(addressIndex++, jAddress.getString("suburb"));
 				//not kept => often introduce "noise" in the address.
 			gAddress.setSubLocality(jAddress.get("suburb").getAsString());
 		}
+
 		if (jAddress.has("postcode")){
 			gAddress.setAddressLine(addressIndex++, jAddress.get("postcode").getAsString());
 			gAddress.setPostalCode(jAddress.get("postcode").getAsString());


### PR DESCRIPTION
Small change: Added the house number because I noticed it was missing in a project where I need the house numbers.

I did not change the address line because some countries put it at the end and some put the number at the beginning of the street name. 