### PR TITLE
Geocoder not work without SSL

### DIFF
--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/GeocoderNominatim.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/location/GeocoderNominatim.java
@@ -31,8 +31,8 @@ import java.util.Locale;
  * @author M.Kergall
  */
 public class GeocoderNominatim {
-	public static final String NOMINATIM_SERVICE_URL = "http://nominatim.openstreetmap.org/";
-	public static final String MAPQUEST_SERVICE_URL = "http://open.mapquestapi.com/nominatim/v1/";
+	public static final String NOMINATIM_SERVICE_URL = "https://nominatim.openstreetmap.org/";
+	public static final String MAPQUEST_SERVICE_URL = "https://open.mapquestapi.com/nominatim/v1/";
 	
 	protected Locale mLocale;
 	protected String mServiceUrl, mKey;


### PR DESCRIPTION
when using the geocoder I get an error: `java.net.UnknownServiceException: CLEARTEXT communication to nominatim.openstreetmap.org not permitted by network security policy`