### PR TITLE
distinguish the tapped marker from other markers

### DIFF
--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/clustering/MarkerClusterer.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/clustering/MarkerClusterer.java
@@ -13,14 +13,14 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.ListIterator;
 
-/** 
- * An overlay allowing to perform markers clustering. 
- * Usage: put your markers inside with add(Marker), and add the MarkerClusterer to the map overlays. 
+/**
+ * An overlay allowing to perform markers clustering.
+ * Usage: put your markers inside with add(Marker), and add the MarkerClusterer to the map overlays.
  * Depending on the zoom level, markers will be displayed separately, or grouped as a single Marker. <br/>
- * 
- * This abstract class provides the framework. Sub-classes have to implement the clustering algorithm, 
- * and the rendering of a cluster. 
- * 
+ *
+ * This abstract class provides the framework. Sub-classes have to implement the clustering algorithm,
+ * and the rendering of a cluster.
+ *
  * @author M.Kergall
  *
  */
@@ -28,23 +28,23 @@ public abstract class MarkerClusterer extends Overlay {
 
 	/** impossible value for zoom level, to force clustering */
 	protected static final int FORCE_CLUSTERING = -1;
-	
+
 	protected ArrayList<Marker> mItems = new ArrayList<Marker>();
 	protected Point mPoint = new Point();
 	protected ArrayList<StaticCluster> mClusters = new ArrayList<StaticCluster>();
 	protected int mLastZoomLevel;
 	protected Bitmap mClusterIcon;
 	protected String mName, mDescription;
-	
-	// abstract methods: 
-	
+
+	// abstract methods:
+
 	/** clustering algorithm */
 	public abstract ArrayList<StaticCluster> clusterer(MapView mapView);
 	/** Build the marker for a cluster. */
 	public abstract Marker buildClusterMarker(StaticCluster cluster, MapView mapView);
 	/** build clusters markers to be used at next draw */
 	public abstract void renderer(ArrayList<StaticCluster> clusters, Canvas canvas, MapView mapView);
-	
+
 	public MarkerClusterer() {
 		super();
 		mLastZoomLevel = FORCE_CLUSTERING;
@@ -53,42 +53,42 @@ public abstract class MarkerClusterer extends Overlay {
 	public void setName(String name){
 		mName = name;
 	}
-	
+
 	public String getName(){
 		return mName;
 	}
-	
+
 	public void setDescription(String description){
 		mDescription = description;
 	}
-	
+
 	public String getDescription(){
 		return mDescription;
 	}
-	
-	/** Set the cluster icon to be drawn when a cluster contains more than 1 marker. 
+
+	/** Set the cluster icon to be drawn when a cluster contains more than 1 marker.
 	 * If not set, default will be the default osmdroid marker icon (which is really inappropriate as a cluster icon). */
 	public void setIcon(Bitmap icon){
 		mClusterIcon = icon;
 	}
-	
-	/** Add the Marker. 
+
+	/** Add the Marker.
 	 * Important: Markers added in a MarkerClusterer should not be added in the map overlays. */
 	public void add(Marker marker){
 		mItems.add(marker);
 	}
-	
-	/** Force a rebuild of clusters at next draw, even without a zooming action. 
+
+	/** Force a rebuild of clusters at next draw, even without a zooming action.
 	 * Should be done when you changed the content of a MarkerClusterer. */
 	public void invalidate(){
-		mLastZoomLevel = FORCE_CLUSTERING; 
+		mLastZoomLevel = FORCE_CLUSTERING;
 	}
-	
+
 	/** @return the Marker at id (starting at 0) */
 	public Marker getItem(int id){
 		return mItems.get(id);
 	}
-	
+
 	/** @return the list of Markers. */
 	public ArrayList<Marker> getItems(){
 		return mItems;
@@ -112,7 +112,7 @@ public abstract class MarkerClusterer extends Overlay {
         	renderer(mClusters, canvas, mapView);
 			mLastZoomLevel = zoomLevel;
 		}
-		
+
 		for (StaticCluster cluster:mClusters){
 			cluster.getMarker().draw(canvas, mapView.getProjection());
         }
@@ -143,6 +143,15 @@ public abstract class MarkerClusterer extends Overlay {
 		};
 	}
 
+	@Override
+	public boolean onSingleTapUp(MotionEvent e, MapView mapView) {
+		for (final StaticCluster cluster : reversedClusters()) {
+			if (cluster.getMarker().onSingleTapUp(e, mapView))
+				return true;
+		}
+		return false;
+	}
+
 	@Override public boolean onSingleTapConfirmed(final MotionEvent event, final MapView mapView){
 		for (final StaticCluster cluster : reversedClusters()) {
 			if (cluster.getMarker().onSingleTapConfirmed(event, mapView))
@@ -150,7 +159,7 @@ public abstract class MarkerClusterer extends Overlay {
 		}
 		return false;
 	}
-	
+
 	@Override public boolean onLongPress(final MotionEvent event, final MapView mapView) {
 		for (final StaticCluster cluster : reversedClusters()) {
 			if (cluster.getMarker().onLongPress(event, mapView))

--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/overlays/MarkerWithStatus.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/overlays/MarkerWithStatus.java
@@ -1,0 +1,41 @@
+package org.osmdroid.bonuspack.overlays;
+
+import android.content.Context;
+import android.view.MotionEvent;
+
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.Marker;
+
+public class MarkerWithStatus extends Marker {
+
+    public MarkerWithStatus(MapView mapView) {
+        super(mapView);
+    }
+
+    public MarkerWithStatus(MapView mapView, Context resourceProxy) {
+        super(mapView, resourceProxy);
+    }
+
+    public void setFocused(boolean mFocused) {
+        if (mIcon == null) return;
+        if (mFocused) {
+            mIcon.setState(new int[]{android.R.attr.state_focused});
+        } else {
+            mIcon.setState(new int[]{android.R.attr.state_single});
+        }
+    }
+
+    @Override
+    public boolean onSingleTapUp(MotionEvent e, MapView mapView) {
+        setFocused(false);
+        return super.onSingleTapUp(e, mapView);
+    }
+
+    @Override
+    public boolean onSingleTapConfirmed(MotionEvent event, MapView mapView) {
+        boolean touched = hitTest(event, mapView);
+        setFocused(touched);
+        return super.onSingleTapConfirmed(event, mapView);
+    }
+
+}

--- a/OSMBonusPackTuto/src/main/res/drawable-mdpi/marker_with_status.xml
+++ b/OSMBonusPackTuto/src/main/res/drawable-mdpi/marker_with_status.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:drawable="@drawable/marker_default" android:state_focused="true" />
+    <item android:drawable="@drawable/marker_default_focused_base" />
+
+</selector>


### PR DESCRIPTION
A low-cost solution to distinguish the tapped marker from other markers with the help of onSingleTapUp & onSingleTapConfirmed method and drawable resources. Works in MarkerClusterer container as well.

Step1. 

add drawable resources that can distinguish status from focused and other status;
marker_with_status.xml
`<?xml version="1.0" encoding="utf-8"?>
<selector xmlns:android="http://schemas.android.com/apk/res/android">

    <item android:drawable="@drawable/marker_default" android:state_focused="true" />
    <item android:drawable="@drawable/marker_default_focused_base" />

</selector>`

Step2.

 replace Marker with MarkerWithStatus, and call setIcon(Drawable icon) method;

`
		MarkerWithStatus startMarker = new MarkerWithStatus(map);
		startMarker.setIcon(ContextCompat.getDrawable(this,R.drawable.marker_with_status));`
