### PR TITLE
Fixes KmlFeature writeAsKML to write the feature's Id rather than the string "mId"

### DIFF
--- a/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/kml/KmlFeature.java
+++ b/OSMBonusPack/src/main/java/org/osmdroid/bonuspack/kml/KmlFeature.java
@@ -197,7 +197,7 @@ public abstract class KmlFeature implements Parcelable, Cloneable {
 				return false;
 			writer.write('<'+objectType);
 			if (mId != null)
-				writer.write(" id=\"+mId+\"");
+				writer.write(" id=\""+mId+"\"");
 			writer.write(">\n");
 			if (mStyle != null){
 				writer.write("<styleUrl>#"+mStyle+"</styleUrl>\n");


### PR DESCRIPTION
From:
`writer.write(" id=\"mId\"");`
To:
`writer.write(" id=\""+mId+"\"");`